### PR TITLE
Enable PWA module and prerender home route

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,14 +1,23 @@
 import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
+  // Disable server-side rendering for SPA mode
   ssr: false,
-  modules: ['@vite-pwa/nuxt'],
+  modules: [
+    '@vite-pwa/nuxt',
+  ],
+  nitro: {
+    prerender: {
+      // Pre-render home page for offline use
+      routes: ['/'],
+    }
+  },
   pwa: {
     registerType: 'autoUpdate',
     manifest: {
-      name: 'Nuxt\u00A03\u00A0PWA',
+      name: 'Nuxt 3 PWA',
       short_name: 'NuxtPWA',
-      description: 'Offline\u2011ready Nuxt\u00A03 app',
+      description: 'A Nuxt 3 Progressive Web App',
       theme_color: '#4A90E2',
       icons: [
         { src: '/pwa-icon-192x192.png', sizes: '192x192', type: 'image/png' },


### PR DESCRIPTION
## Summary
- configure SPA mode in `nuxt.config.ts`
- enable PWA module with manifest settings
- add `nitro.prerender.routes` for offline home page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684116a89f54833385b44e9216202a3f