### PR TITLE
Add API runtime cache to workbox config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -34,6 +34,14 @@ export default defineNuxtConfig({
             cacheName: 'image-cache',
             expiration: { maxEntries: 100, maxAgeSeconds: 604800 }
           }
+        },
+        {
+          urlPattern: 'https://example.com/.*',
+          handler: 'NetworkFirst',
+          options: {
+            cacheName: 'api-cache',
+            expiration: { maxEntries: 50, maxAgeSeconds: 86400 }
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary
- extend `runtimeCaching` in `nuxt.config.ts` with an API cache entry

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684119aaab8083339e8ecbcd58e32f4a