### PR TITLE
Add offline demo home page

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
     <NuxtRouteAnnouncer />
-    <NuxtWelcome />
+    <NuxtPage />
   </div>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,7 +23,7 @@ export default defineNuxtConfig({
       ]
     },
     workbox: {
-      globPatterns: ['**/*.{js,css,html,png,svg,ico}'],
+      globPatterns: ['**/*.{js,css,html,png,svg,ico,json}'],
       cleanupOutdatedCaches: true,
       clientsClaim: true,
       runtimeCaching: [

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+const availableMemory = ref('Calculating...')
+const message = ref('')
+
+onMounted(async () => {
+  if (navigator.storage && navigator.storage.estimate) {
+    try {
+      const { usage = 0, quota = 0 } = await navigator.storage.estimate()
+      const free = quota - usage
+      availableMemory.value = `${(free / (1024 * 1024)).toFixed(2)} MB`
+    } catch {
+      availableMemory.value = 'Unknown'
+    }
+  } else {
+    availableMemory.value = 'Unknown'
+  }
+})
+
+async function fetchMessage() {
+  try {
+    const res = await fetch('/hello.json')
+    const data = await res.json()
+    message.value = data.message
+  } catch {
+    message.value = 'Failed to load message'
+  }
+}
+</script>
+
+<template>
+  <main class="p-4">
+    <h1 class="text-xl font-bold mb-4">Home Page</h1>
+    <p class="mb-2">Available Storage: {{ availableMemory }}</p>
+    <button @click="fetchMessage" class="px-3 py-1 bg-blue-500 text-white rounded">Fetch Offline Message</button>
+    <p class="mt-2">{{ message }}</p>
+  </main>
+</template>

--- a/public/hello.json
+++ b/public/hello.json
@@ -1,0 +1,1 @@
+{ "message": "Hello from offline cache!" }


### PR DESCRIPTION
## Summary
- add simple home page with storage display
- allow JSON files in workbox precache
- load new page instead of Nuxt Welcome
- add a precached `hello.json` for offline demo

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68411b595f808333b32d6ba03d99b8ba