### PR TITLE
Add PWA memory page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -35,5 +35,6 @@ async function fetchMessage() {
     <p class="mb-2">Available Storage: {{ availableMemory }}</p>
     <button @click="fetchMessage" class="px-3 py-1 bg-blue-500 text-white rounded">Fetch Offline Message</button>
     <p class="mt-2">{{ message }}</p>
+    <NuxtLink to="/memory" class="text-blue-500 underline mt-4 inline-block">View Available Memory</NuxtLink>
   </main>
 </template>

--- a/pages/memory.vue
+++ b/pages/memory.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+const availableMemory = ref('Calculating...')
+
+onMounted(async () => {
+  if (navigator.storage && navigator.storage.estimate) {
+    try {
+      const { usage = 0, quota = 0 } = await navigator.storage.estimate()
+      const free = quota - usage
+      availableMemory.value = `${(free / (1024 * 1024)).toFixed(2)} MB`
+    } catch {
+      availableMemory.value = 'Unknown'
+    }
+  } else {
+    availableMemory.value = 'Unknown'
+  }
+})
+</script>
+
+<template>
+  <main class="p-4">
+    <h1 class="text-xl font-bold mb-4">Available Memory</h1>
+    <p>Available Storage: {{ availableMemory }}</p>
+    <NuxtLink to="/" class="text-blue-500 underline mt-4 inline-block">Back to Home</NuxtLink>
+  </main>
+</template>


### PR DESCRIPTION
## Summary
- create a new `memory` page that shows available storage space
- link to the new page from the home page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68411e0d52548333a36e7508828cbce4