### PR TITLE
Add offline test page

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,7 +7,7 @@ export default defineNuxtConfig({
   ],
   nitro: {
     prerender: {
-      routes: ['/'],  // Pre-render home page for offline use
+      routes: ['/', '/offline'],  // Pre-render pages for offline use
     }
   },
   pwa: {

--- a/pages/offline.vue
+++ b/pages/offline.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const status = ref('Click to test offline caching')
+
+async function showMessage() {
+  try {
+    const res = await fetch('/hello.json')
+    const data = await res.json()
+    status.value = data.message
+  } catch {
+    status.value = 'Failed to load message'
+  }
+}
+</script>
+
+<template>
+  <main class="p-4">
+    <h1 class="text-xl font-bold mb-4">Offline Test</h1>
+    <button @click="showMessage" class="px-3 py-1 bg-blue-500 text-white rounded">Test Offline</button>
+    <p class="mt-2">{{ status }}</p>
+  </main>
+</template>


### PR DESCRIPTION
## Summary
- add an `offline` page with a button that fetches a cached file
- prerender the `/offline` route so it's available offline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68411e2dd1bc83338d8df6d78539903b