### PR TITLE
Add PDF upload page

### DIFF
--- a/pages/upload.vue
+++ b/pages/upload.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const selectedFile = ref<File | null>(null)
+const fileInput = ref<HTMLInputElement | null>(null)
+
+function onFileChange(e: Event) {
+  const files = (e.target as HTMLInputElement).files
+  if (files && files[0]) {
+    selectedFile.value = files[0]
+  }
+}
+
+function onDrop(e: DragEvent) {
+  e.preventDefault()
+  const files = e.dataTransfer?.files
+  if (files && files[0]) {
+    selectedFile.value = files[0]
+  }
+}
+
+function onDragOver(e: DragEvent) {
+  e.preventDefault()
+}
+</script>
+
+<template>
+  <main class="p-4">
+    <h1 class="text-xl font-bold mb-4">Upload PDF</h1>
+    <div
+      class="border-2 border-dashed rounded p-8 text-center cursor-pointer"
+      @drop="onDrop"
+      @dragover="onDragOver"
+      @click="fileInput?.click()"
+    >
+      <p v-if="!selectedFile">Drag and drop a PDF here or click to choose</p>
+      <p v-else>Selected file: {{ selectedFile.name }}</p>
+      <input
+        ref="fileInput"
+        type="file"
+        accept="application/pdf"
+        class="hidden"
+        @change="onFileChange"
+      />
+    </div>
+  </main>
+</template>


### PR DESCRIPTION
## Summary
- create `/upload` page with drag-and-drop or file chooser to upload PDF

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68411e8e7b28833382a60e5852ee613a