### PR TITLE
Add client-side memory usage monitor

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,11 @@
+<script setup lang="ts">
+import MemoryUsage from './components/MemoryUsage.vue'
+</script>
+
 <template>
   <div>
     <NuxtRouteAnnouncer />
+    <MemoryUsage />
     <NuxtPage />
   </div>
 </template>

--- a/components/MemoryUsage.vue
+++ b/components/MemoryUsage.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useMemoryMonitor } from '../composables/useMemoryMonitor'
+
+const { usedJSHeapSize } = useMemoryMonitor()
+
+const memoryMB = computed(() => {
+  return usedJSHeapSize.value !== null
+    ? (usedJSHeapSize.value / (1024 * 1024)).toFixed(2)
+    : 'N/A'
+})
+
+const supported = computed(() => usedJSHeapSize.value !== null)
+</script>
+
+<template>
+  <div class="fixed bottom-0 right-0 p-1 text-xs text-gray-600">
+    <span v-if="supported">Memory: {{ memoryMB }} MB</span>
+    <span v-else>Memory: N/A</span>
+  </div>
+</template>

--- a/composables/useMemoryMonitor.ts
+++ b/composables/useMemoryMonitor.ts
@@ -1,0 +1,31 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+
+export function useMemoryMonitor(interval = 1000) {
+  const usedJSHeapSize = ref<number | null>(null)
+  let timer: ReturnType<typeof setInterval> | null = null
+
+  const update = () => {
+    const perf: any = (window as any).performance
+    if (perf && perf.memory) {
+      usedJSHeapSize.value = perf.memory.usedJSHeapSize
+    } else {
+      usedJSHeapSize.value = null
+    }
+  }
+
+  onMounted(() => {
+    const perf: any = (window as any).performance
+    if (perf && perf.memory) {
+      update()
+      timer = setInterval(update, interval)
+    }
+  })
+
+  onUnmounted(() => {
+    if (timer) {
+      clearInterval(timer)
+    }
+  })
+
+  return { usedJSHeapSize }
+}

--- a/dev/status/brainpdf-checklist.md
+++ b/dev/status/brainpdf-checklist.md
@@ -1,0 +1,6 @@
+# BrainPDF Development Checklist
+
+## Memory Usage Monitor
+- [x] Monitor utility created
+- [x] MemoryUsage component displays data
+- [x] Integrated into layout


### PR DESCRIPTION
## Summary
- monitor memory usage via `useMemoryMonitor` composable
- display live heap consumption in `MemoryUsage` component
- integrate memory usage display in `app.vue`
- track progress in `dev/status/brainpdf-checklist.md`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68424fb53abc833397980d9a3219be94