### PR TITLE
Add PDF type check on drop

### DIFF
--- a/components/PdfDropZone.vue
+++ b/components/PdfDropZone.vue
@@ -5,6 +5,7 @@ import { usePdfStore } from '~/stores/pdfStore'
 const store = usePdfStore()
 const fileInput = ref<HTMLInputElement | null>(null)
 const isDragging = ref(false)
+const errorMessage = ref('')
 
 function handleFiles(files: FileList | null) {
   if (!files || !files[0]) return
@@ -18,7 +19,15 @@ function handleFiles(files: FileList | null) {
 function onDrop(e: DragEvent) {
   e.preventDefault()
   isDragging.value = false
-  handleFiles(e.dataTransfer?.files ?? null)
+  const files = e.dataTransfer?.files
+  if (files && files[0]) {
+    if (files[0].type === 'application/pdf') {
+      errorMessage.value = ''
+      handleFiles(files)
+    } else {
+      errorMessage.value = 'Only PDF files are supported'
+    }
+  }
 }
 
 function onDragOver(e: DragEvent) {
@@ -53,4 +62,5 @@ function openFile() {
     <p v-else>{{ store.file.name }} ({{ (store.file.size / 1024).toFixed(1) }} KB)</p>
     <input ref="fileInput" type="file" accept="application/pdf" class="hidden" @change="onFileChange" />
   </div>
+  <p v-if="errorMessage" class="text-red-500 mt-2">{{ errorMessage }}</p>
 </template>

--- a/pages/upload.vue
+++ b/pages/upload.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 
 const selectedFile = ref<File | null>(null)
 const fileInput = ref<HTMLInputElement | null>(null)
+const errorMessage = ref('')
 
 function onFileChange(e: Event) {
   const files = (e.target as HTMLInputElement).files
@@ -15,7 +16,12 @@ function onDrop(e: DragEvent) {
   e.preventDefault()
   const files = e.dataTransfer?.files
   if (files && files[0]) {
-    selectedFile.value = files[0]
+    if (files[0].type === 'application/pdf') {
+      errorMessage.value = ''
+      selectedFile.value = files[0]
+    } else {
+      errorMessage.value = 'Only PDF files are supported'
+    }
   }
 }
 
@@ -43,5 +49,6 @@ function onDragOver(e: DragEvent) {
         @change="onFileChange"
       />
     </div>
+    <p v-if="errorMessage" class="text-red-500 mt-2">{{ errorMessage }}</p>
   </main>
 </template>


### PR DESCRIPTION
## Summary
- verify MIME type when dropping files
- show an error message for non-PDF drops

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684252c8a15083339ed26867129052e8