### PR TITLE
Add CI and setup instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: pnpm install
+      - run: pnpm build
+      - run: pnpm test

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ yarn install
 bun install
 ```
 
+Install these dependencies before running `npm test` or `npm run build`.
+
 ## Development Server
 
 Start the development server on `http://localhost:3000`:


### PR DESCRIPTION
## Summary
- mention that dependencies must be installed before running tests or builds
- add CI workflow to install packages and run build/test

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684252b44a1483339c37eb949efff22d